### PR TITLE
Update with new domains 增加新的acfun.tudou.com的域名。

### DIFF
--- a/acfun/AcFun_ASS_Danmaku_Downloader.meta.js
+++ b/acfun/AcFun_ASS_Danmaku_Downloader.meta.js
@@ -2,8 +2,9 @@
 // @name        AcFun ASS Danmaku Downloader
 // @namespace   https://github.com/tiansh
 // @description 以 ASS 格式下载 AcFun 的弹幕
-// @include     http://www.acfun.com/v/ac*
-// @include     http://www.acfun.tv/v/ac*
+// @include     http://www.acfun.com/v/*
+// @include     http://www.acfun.tv/v/*
+// @include     http://acfun.tudou.com/v/*
 // @updateURL   https://tiansh.github.io/us-danmaku/acfun/AcFun_ASS_Danmaku_Downloader.meta.js
 // @downloadURL https://tiansh.github.io/us-danmaku/acfun/AcFun_ASS_Danmaku_Downloader.user.js
 // @version     1.13

--- a/acfun/AcFun_ASS_Danmaku_Downloader.user.js
+++ b/acfun/AcFun_ASS_Danmaku_Downloader.user.js
@@ -4,6 +4,7 @@
 // @description 以 ASS 格式下载 AcFun 的弹幕
 // @include     http://www.acfun.com/v/*
 // @include     http://www.acfun.tv/v/*
+// @include     http://acfun.tudou.com/v/*
 // @updateURL   https://tiansh.github.io/us-danmaku/acfun/AcFun_ASS_Danmaku_Downloader.meta.js
 // @downloadURL https://tiansh.github.io/us-danmaku/acfun/AcFun_ASS_Danmaku_Downloader.user.js
 // @version     1.13


### PR DESCRIPTION
看Jojo第四部， http://acfun.tudou.com/v/ab1470445_1
发现acfun的土豆源现在用一个新的域名。